### PR TITLE
Dynamic gas pricing strategy (GeometricGasPrice)

### DIFF
--- a/tests/keeper.test.js
+++ b/tests/keeper.test.js
@@ -9,8 +9,6 @@ import oasisDexAdaptor from '../src/dex/oasisdex';
 import config from '../config/testchain.json';
 import clipper from "../src/clipper";
 import keeper from "../src/keeper";
-import { Transact, GeometricGasPrice } from "../src/transact"
-import daiAbi from '../abi/Dai.json';
 
 network.rpcURL = 'http://localhost:2000';
 Config.vars = config;
@@ -73,23 +71,3 @@ test('check order book', async () => {
   await oasis.fetch();
   expect(ethers.utils.formatUnits(await oasis.opportunity(ethers.utils.parseUnits('0.9')))).toBe('0.5');
 },10000);
-
-test('txn-manager: try transaction w/ node gasStrategy', async () => {
-
-  const dai = new ethers.Contract(Config.vars.dai, daiAbi, signer.provider);
-  const approval_transaction = await dai.populateTransaction.approve(Config.vars.OasisDex, ethers.utils.parseEther("1.0"));
-  const txn = new Transact(approval_transaction, signer, Config.vars.txnReplaceTimeout);
-  await txn.transact_async();
-
-}, 10000)
-
-test('txn-manager: try transaction w/ geometric gasStrategy', async () => {
-
-  const dai = new ethers.Contract(Config.vars.dai, daiAbi, signer.provider);
-  const approval_transaction = await dai.populateTransaction.approve(Config.vars.OasisDex, ethers.utils.parseEther("1.0"));
-  const initial_price = await signer.getGasPrice()
-  const gasStrategy = new GeometricGasPrice(initial_price.toNumber(), (Config.vars.txnReplaceTimeout / 1000))
-  const txn = new Transact(approval_transaction, signer, Config.vars.txnReplaceTimeout, gasStrategy);
-  await txn.transact_async();
-
-}, 20000)

--- a/tests/transact.test.js
+++ b/tests/transact.test.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+import { ethers } from 'ethers';
+import Config from '../src/singleton/config';
+import network from '../src/singleton/network';
+import {expect} from "@jest/globals";
+import config from '../config/testchain.json';
+import { Transact, GeometricGasPrice } from "../src/transact"
+import daiAbi from '../abi/Dai.json';
+
+network.rpcURL = 'http://localhost:2000';
+Config.vars = config;
+
+
+const sleep = async function(delay) {await new Promise((r) => setTimeout(r, delay));};
+
+// Testchain Deployer Address
+const privateKey = "0x474BEB999FED1B3AF2EA048F963833C686A0FBA05F5724CB6417CF3B8EE9697E";
+const signer = new ethers.Wallet(privateKey, network.provider);
+console.log("Address: " + signer.address);
+
+// https://github.com/makerdao/pymaker/blob/634291f12fc8c858c2c40379d114f0b87f1832c5/tests/test_gas.py#L166
+test('txn-manager: GeometricGasPrice should increase with time', async () => {
+  // given 100 wei initial price, increasing every 10 seconds
+  const gasStrategy = new GeometricGasPrice(100, 10)
+
+  // expect
+  expect(gasStrategy.get_gas_price(0)).toBe(100)
+  expect(gasStrategy.get_gas_price(1)).toBe(100)
+  expect(gasStrategy.get_gas_price(10)).toBe(113)
+  expect(gasStrategy.get_gas_price(15)).toBe(113)
+  expect(gasStrategy.get_gas_price(20)).toBe(127)
+  expect(gasStrategy.get_gas_price(30)).toBe(143)
+  expect(gasStrategy.get_gas_price(50)).toBe(181)
+  expect(gasStrategy.get_gas_price(100)).toBe(325)
+
+}, 10000)
+
+// https://github.com/makerdao/pymaker/blob/634291f12fc8c858c2c40379d114f0b87f1832c5/tests/test_gas.py#L180
+test('txn-manager: GeometricGasPrice should obey max value', async () => {
+  // given 1000 wei initial price, increasing every 60 seconds, 12.5% bump, 2500 wei max
+  const gasStrategy = new GeometricGasPrice(1000, 60, 1.125, 2500)
+
+  // expect
+  expect(gasStrategy.get_gas_price(0)).toBe(1000)
+  expect(gasStrategy.get_gas_price(1)).toBe(1000)
+  expect(gasStrategy.get_gas_price(59)).toBe(1000)
+  expect(gasStrategy.get_gas_price(60)).toBe(1125)
+  expect(gasStrategy.get_gas_price(119)).toBe(1125)
+  expect(gasStrategy.get_gas_price(120)).toBe(1266)
+  expect(gasStrategy.get_gas_price(1200)).toBe(2500)
+  expect(gasStrategy.get_gas_price(3000)).toBe(2500)
+  expect(gasStrategy.get_gas_price(1000000)).toBe(2500)
+
+}, 10000)
+
+// https://github.com/makerdao/pymaker/blob/634291f12fc8c858c2c40379d114f0b87f1832c5/tests/test_gas.py#L195
+test('txn-manager: GeometricGasPrice behaves with realistic values', async () => {
+  // given
+  const GWEI = 1000000000
+  const gasStrategy = new GeometricGasPrice(100*GWEI, 10, 1+(0.125*2))
+
+  const cycles = [0, 1, 10, 12, 30, 60];
+  cycles.forEach(seconds => {
+    console.log(`Gas price after ${seconds} seconds is ${gasStrategy.get_gas_price(seconds)/GWEI}`)
+  })
+
+  // expect
+  expect(Math.round(gasStrategy.get_gas_price(0) / GWEI)).toBe(100)
+  expect(Math.round(gasStrategy.get_gas_price(1) / GWEI)).toBe(100)
+  expect(Math.round(gasStrategy.get_gas_price(10) / GWEI)).toBe(125)
+  expect(Math.round(gasStrategy.get_gas_price(12) / GWEI)).toBe(125)
+  expect(Math.round(gasStrategy.get_gas_price(30) / GWEI)).toBe(195)
+  expect(Math.round(gasStrategy.get_gas_price(60) / GWEI)).toBe(381)
+
+}, 10000)
+
+
+test('txn-manager: try transaction wth node gasStrategy', async () => {
+  const dai = new ethers.Contract(Config.vars.dai, daiAbi, signer.provider);
+  const approval_transaction = await dai.populateTransaction.approve(Config.vars.OasisDex, ethers.utils.parseEther("1.0"));
+  const txn = new Transact(approval_transaction, signer, Config.vars.txnReplaceTimeout);
+  await txn.transact_async();
+}, 10000)
+
+test('txn-manager: try transaction w/ geometric gasStrategy', async () => {
+
+  const dai = new ethers.Contract(Config.vars.dai, daiAbi, signer.provider);
+  const approval_transaction = await dai.populateTransaction.approve(Config.vars.OasisDex, ethers.utils.parseEther("1.0"));
+  const initial_price = await signer.getGasPrice()
+  const gasStrategy = new GeometricGasPrice(initial_price.toNumber(), (Config.vars.txnReplaceTimeout / 1000))
+  const txn = new Transact(approval_transaction, signer, Config.vars.txnReplaceTimeout, gasStrategy);
+  await txn.transact_async();
+
+}, 20000)


### PR DESCRIPTION
Implemented pymaker's [GeometricGasPrice](https://github.com/makerdao/pymaker/blob/634291f12fc8c858c2c40379d114f0b87f1832c5/pymaker/gas.py#L168) strategy in Javascript. 

In short, the `GeometricGasPrice` JS class takes an `initial price`, bumps the price `every_secs`, by some `coefficient` (defaults to 12.5%, OpenEthereum's minimum for txn replacement) and continues until a `max_price` is reached (if defined). Gas price is in `wei`.

`GeometricGasPrice` exposes a `get_gas_price(time_elapsed)` function, which takes in the seconds elapsed since the original transaction and returns the appropriate gas price. 