### PR TITLE
added kovan config file [ch7728]

### DIFF
--- a/config/kovan.json
+++ b/config/kovan.json
@@ -1,0 +1,21 @@
+{
+    "rpcURL": "https://kovan.infura.io/v3...",
+    "dai": "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa",
+    "MakerOTCSupportMethods": "0x303f2bf24d98325479932881657f45567b3e47a8",
+    "OasisDex": "0xe325acB9765b02b8b418199bf9650972299235F4",
+    "txnReplaceTimeout": "5000",
+    "delay": "5000",
+    "collateral": {
+      "ETH-A": {
+        "name": "ETH-A",
+        "erc20addr": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
+        "clipper": "",
+        "abacus": "",
+        "callee": ""
+      }
+    },
+    "minProfitNum": "5",
+    "minProfitDen": "100",
+    "minSize": "1"
+  }
+  

--- a/tests/keeper.test.js
+++ b/tests/keeper.test.js
@@ -34,7 +34,8 @@ test('keeper initialization, and one opportunity check loop', async () => {
 }, 10000);
 
 test('basic connectivity', async () => {
-  expect(typeof (await network.provider.getNetwork()).chainId).toBe('number');
+  let id = await network.provider.getNetwork();
+  expect(typeof id.chainId).toBe('number');
 });
 
 test('read active auctions', async () => {


### PR DESCRIPTION
Purpose of this PR is to confirm that the wallet module accepts a KOVAN Infura RPC url and it is functional. The 'basic connectivity' test confirms that the urls works by reading the network ID. 

To test that the Kovan RPC URL is validated by ethers js I have made some manual changes in the `tests/keeper.test.js`file. 
I've changed `network.rpcURL = 'http://localhost:2000'`; to `network.rpcURL = 'infura_url` on line [16](https://github.com/makerdao/auction-demo-keeper/blob/ae05bebcef94ec19a3b1d574227d3cfe740d24c5/tests/keeper.test.js#L16)
and ran the below [test function](https://github.com/makerdao/auction-demo-keeper/blob/ae05bebcef94ec19a3b1d574227d3cfe740d24c5/tests/keeper.test.js#L36) which should test that the kovan network ID is 42
```
test('basic connectivity', async () => {
  let id = await network.provider.getNetwork();
  expect(typeof id.chainId).toBe(42);
});
```
