### PR TITLE
Chost

### DIFF
--- a/abi/clipper.json
+++ b/abi/clipper.json
@@ -265,6 +265,13 @@
   },
   {
     "inputs": [],
+    "name": "chost",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "count",
     "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
@@ -290,13 +297,6 @@
     "outputs": [
       { "internalType": "contract DogLike", "name": "", "type": "address" }
     ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "dust",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -443,7 +443,7 @@
   },
   {
     "inputs": [],
-    "name": "updust",
+    "name": "upchost",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/config/kovan.json
+++ b/config/kovan.json
@@ -20,6 +20,30 @@
         "0xa36085F69e2889c224210F603D836748e7dC0088",
         "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa"
       ]
+    },
+    "YFI-A": {
+      "name": "YFI-A",
+      "erc20addr": "0x251F1c3077FEd1770cB248fB897100aaE1269FFC",
+      "joinAdapter": "0x5b683137481F2FE683E2f2385792B1DeB018050F",
+      "clipper": "0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2",
+      "oasisCallee": "0x49fE9B3d7C7c996b3019dc36ea867daa807cD8d7",
+      "uniswapCallee": "0xF7B65111bFE0bA6f5f61F01492dAA1C1b011E346",
+      "uniswapRoute": [
+        "0x251F1c3077FEd1770cB248fB897100aaE1269FFC",
+        "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa"
+      ]
+    },
+    "WBTC-A": {
+      "name": "WBTC-A",
+      "erc20addr": "0x7419f744bBF35956020C1687fF68911cD777f865",
+      "joinAdapter": "0xB879c7d51439F8e7AC6b2f82583746A0d336e63F",
+      "clipper": "0x5518C2f409Bed4bD5FF3542d9D5002251EEDA892",
+      "oasisCallee": "0x3DdD8d18F46A723aE7Aef72e8b84b0D3dA1088C5",
+      "uniswapCallee": "0xF7B65111bFE0bA6f5f61F01492dAA1C1b011E346",
+      "uniswapRoute": [
+        "0x7419f744bBF35956020C1687fF68911cD777f865",
+        "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa"
+      ]
     }
   },
   "txnReplaceTimeout": "20",

--- a/config/kovan.json
+++ b/config/kovan.json
@@ -7,7 +7,7 @@
   "UniswapV2Router": "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
   "vat": "0xbA987bDB501d131f766fEe8180Da5d81b34b69d9",
   "eth": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
-  "liquidityProvider": "uniswap",
+  "liquidityProvider": "oasisdex",
   "collateral": {
     "LINK-A": {
       "name": "LINK-A",
@@ -18,30 +18,6 @@
       "uniswapCallee": "0xF7B65111bFE0bA6f5f61F01492dAA1C1b011E346",
       "uniswapRoute": [
         "0xa36085F69e2889c224210F603D836748e7dC0088",
-        "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa"
-      ]
-    },
-    "YFI-A": {
-      "name": "YFI-A",
-      "erc20addr": "0x251F1c3077FEd1770cB248fB897100aaE1269FFC",
-      "joinAdapter": "0x5b683137481F2FE683E2f2385792B1DeB018050F",
-      "clipper": "0x9020C96B06d2ac59e98A0F35f131D491EEcAa2C2",
-      "oasisCallee": "0x49fE9B3d7C7c996b3019dc36ea867daa807cD8d7",
-      "uniswapCallee": "0xF7B65111bFE0bA6f5f61F01492dAA1C1b011E346",
-      "uniswapRoute": [
-        "0x251F1c3077FEd1770cB248fB897100aaE1269FFC",
-        "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa"
-      ]
-    },
-    "WBTC-A": {
-      "name": "WBTC-A",
-      "erc20addr": "0x7419f744bBF35956020C1687fF68911cD777f865",
-      "joinAdapter": "0xB879c7d51439F8e7AC6b2f82583746A0d336e63F",
-      "clipper": "0x5518C2f409Bed4bD5FF3542d9D5002251EEDA892",
-      "oasisCallee": "0x3DdD8d18F46A723aE7Aef72e8b84b0D3dA1088C5",
-      "uniswapCallee": "0xF7B65111bFE0bA6f5f61F01492dAA1C1b011E346",
-      "uniswapRoute": [
-        "0x7419f744bBF35956020C1687fF68911cD777f865",
         "0x4F96Fe3b7A6Cf9725f59d353F723c1bDb64CA6Aa"
       ]
     }

--- a/scripts/create-auctions.js
+++ b/scripts/create-auctions.js
@@ -36,7 +36,7 @@ BigNumber.config = { ROUNDING_MODE: BigNumber.ROUND_DOWN };
 let maker;
 let web3;
 let kprAddress = '';
-const lockAmount = 5;
+const lockAmount = 12;
 
 const dogAddress = '0x121D0953683F74e9a338D40d9b4659C0EBb539a0'; // setup dog contract address
 const privateKey = ''; // insert wallet private key
@@ -225,7 +225,7 @@ const kovanAddresses = {
         smartContract: {
             addressOverrides
         },
-        url: 'https://kovan.infura.io/v3/c7c45c0e046e49feb141d72680af4f0a',
+        url: 'https://kovan.infura.io/v3/11465e3f27b247eb8b785c23047b29fd',
         privateKey: privateKey,
         web3: {
             transactionSettings: {

--- a/scripts/create-auctions.js
+++ b/scripts/create-auctions.js
@@ -36,7 +36,7 @@ BigNumber.config = { ROUNDING_MODE: BigNumber.ROUND_DOWN };
 let maker;
 let web3;
 let kprAddress = '';
-const lockAmount = 10;
+const lockAmount = 5;
 
 const dogAddress = '0x121D0953683F74e9a338D40d9b4659C0EBb539a0'; // setup dog contract address
 const privateKey = ''; // insert wallet private key
@@ -225,7 +225,7 @@ const kovanAddresses = {
         smartContract: {
             addressOverrides
         },
-        url: 'https://kovan.infura.io/v3/11465e3f27b247eb8b785c23047b29fd',
+        url: 'https://kovan.infura.io/v3/c7c45c0e046e49feb141d72680af4f0a',
         privateKey: privateKey,
         web3: {
             transactionSettings: {

--- a/src/clipper.js
+++ b/src/clipper.js
@@ -14,6 +14,7 @@ export default class Clipper {
   _abacus;
   _abacusAddr;
   _activeAuctions = [];
+  _chost;
 
   _kickListener;
   _takeListener;
@@ -36,6 +37,9 @@ export default class Clipper {
 
     // _clipper.calc() returns the abacus address of the collateral
     this._abacusAddr = await this._clipper.calc();
+
+    //chost = ilk.dust * ilk.chop(liquidation penalty)
+    this._chost = await this._clipper.chost();
 
     // initialize the abacus contract obbject
     this._abacus = new ethers.Contract(this._abacusAddr, abacusAbi, network.provider);

--- a/src/keeper.js
+++ b/src/keeper.js
@@ -64,6 +64,7 @@ export default class keeper {
         const decimals27 = ethers.utils.parseEther('1000000000');
         let minProfitPercentage = ethers.utils.parseEther(Config.vars.minProfitPercentage);
 
+        const tab = auction.tab.div(decimal18);
         let calc = auction.price.mul(minProfitPercentage);
         let priceWithProfit = calc.div(decimal18);
 
@@ -71,14 +72,21 @@ export default class keeper {
         //adjusting lot to lotDaiValue
         let lotDaiValue = ethers.utils.parseEther(Config.vars.lotDaiValue).mul(decimal18);
         let minLot = lotDaiValue.div(auction.price.div(decimals9));
-        const lot = (auction.lot.toString());
+        let lot;
+
+        //checking for partial lot condition
+        let chost = clip._chost;
+        if(tab < chost) {
+          lot = auction.lot;
+        } else {
+          lot = minLot;
+        }
 
         // Pass in the entire auction size into Uniswap and store the Dai proceeds form the trade
-        await uniswap.fetch(minLot);
+        await uniswap.fetch(lot);
         // Find the minimum effective exchange rate between collateral/Dai
         // e.x. ETH price 1000 DAI -> minimum profit of 1% -> new ETH price is 1000*1.01 = 1010
         
-        const tab = auction.tab.div(decimal18);
         const calcMinProfit45 = tab.mul(minProfitPercentage);
         const totalMinProfit45 = calcMinProfit45.sub(auction.tab);
         const minProfit = totalMinProfit45.div(decimals27);
@@ -91,7 +99,7 @@ export default class keeper {
         let uniswapProceeds = uniswap.opportunity();
 
         const minUniProceeds = Number(uniswapProceeds.receiveAmount) - (Number(ethers.utils.formatUnits(minProfit)));
-        const costOfLot = priceWithProfit.mul(minLot).div(decimals27);
+        const costOfLot = priceWithProfit.mul(lot).div(decimals27);
 
 
         //TODO: Determine if we already have a pending bid for this auction
@@ -100,6 +108,7 @@ export default class keeper {
             ${collateral.name} auction ${auction.id}
 
             Auction Tab: ${ethers.utils.formatUnits(auction.tab.div(decimals27))}
+            Auction Lot: ${ethers.utils.formatUnits(auction.lot.toString())}
             Auction Gem Price: ${ethers.utils.formatUnits(auction.price.div(decimals9))}
             Gem price with profit: ${ethers.utils.formatUnits(priceWithProfit.div(decimals9))}
 
@@ -110,8 +119,7 @@ export default class keeper {
             -- OasisDEX --
             OasisDEXAvailability: amt of collateral avl to buy ${ethers.utils.formatUnits(oasisDexAvailability)}
 
-            amt - lot: ${ethers.utils.formatUnits(lot)}
-            amt - minLot: ${ethers.utils.formatUnits(minLot)}
+            Lot sale amt - lot: ${ethers.utils.formatUnits(lot)}
             costOfLot: ${ethers.utils.formatUnits(costOfLot)}
             maxPrice ${ethers.utils.formatUnits(auction.price.div(decimals9))} Dai
             minProfit: ${ethers.utils.formatUnits(minProfit)} Dai
@@ -122,7 +130,7 @@ export default class keeper {
           case 'uniswap':
             if (Number(ethers.utils.formatUnits(costOfLot)) <= minUniProceeds) {
               //Uniswap tx executes only if the return amount also covers the minProfit %
-              await clip.execute(auction.id, minLot, auction.price, minProfit, this._wallet.address, this._gemJoinAdapters[collateral.name], this._wallet, this._uniswapCalleeAdr);
+              await clip.execute(auction.id, lot, auction.price, minProfit, this._wallet.address, this._gemJoinAdapters[collateral.name], this._wallet, this._uniswapCalleeAdr);
             } else {
               console.log('Uniswap proceeds - profit amount is less than cost.\n');
             }
@@ -130,7 +138,7 @@ export default class keeper {
           case 'oasisdex':
             //OasisDEX buys gem only with gem price + minProfit%
             if (oasisDexAvailability.gt(auction.lot)) {
-              await clip.execute(auction.id, minLot, auction.price, minProfit, this._wallet.address, this._gemJoinAdapters[collateral.name], this._wallet, this._oasisCalleeAdr);
+              await clip.execute(auction.id, lot, auction.price, minProfit, this._wallet.address, this._gemJoinAdapters[collateral.name], this._wallet, this._oasisCalleeAdr);
             } else {
               console.log('Not enough liquidity on OasisDEX\n');
             }

--- a/src/keeper.js
+++ b/src/keeper.js
@@ -76,7 +76,7 @@ export default class keeper {
 
         //checking for partial lot condition
         let chost = clip._chost;
-        if(tab < chost) {
+        if(tab - lotDaiValue < chost) {
           lot = auction.lot;
         } else {
           lot = minLot;


### PR DESCRIPTION
added checker for `require(tab > _chost, "Clipper/no-partial-purchase")` revert issue. 

Keeper will now adapt `lot` sale amt according to `dust` limit. If take `lot` amt puts `tab` value below `chost`, then it will take the full auction `lot` amount instead, bypassing `minLot` value defined in the config. 