### PR TITLE
Improve lot management

### DIFF
--- a/config/kovan.json
+++ b/config/kovan.json
@@ -43,5 +43,6 @@
   "dynamicGasCoefficient": "1.125",
   "maxGasPrice": "10",
   "minProfitPercentage": "1.025",
-  "lotDaiValue": "110"
+  "minLotDaiValue": "0",
+  "maxLotDaiValue": "1000000"
 }

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -204,5 +204,6 @@
   "dynamicGasCoefficient": "1.125",
   "maxGasPrice": "200",
   "minProfitPercentage": "1.025",
-  "lotDaiValue": "5000"
+  "minLotDaiValue": "0",
+  "maxLotDaiValue": "1000000"
 }

--- a/config/testchain.json
+++ b/config/testchain.json
@@ -18,5 +18,7 @@
   "delay": "5",
   "dynamicGasCoefficient": "1.125",
   "maxGasPrice": "500",
-  "minProfitPercentage": "1.01"
+  "minProfitPercentage": "1.01",
+  "minLotDaiValue": "0",
+  "maxLotDaiValue": "1000000"
 }


### PR DESCRIPTION
**Changes**
- The previous implementation assumed that, from the start of the auction, `lot` amount of Gem would be received for a bid of `price * lot`.  This isn't true; while the auction price is higher than `tab`, some collateral is returned to the vault.  I've updated the keeper to calculate `slice`, such that Dai proceeds are calculated based upon the amount of collateral which would be received if a bid at the current price was accepted.
- The `daiAmount` configuration was confusing; it seemed to be used as a max amount, but when converted to Gem terms, was labeled as a minAmount in code.  As an enhancement, I created separate configuration knobs which can be used to limit participation in small gas-inefficient takes (`minLotDaiValue`) and a maximum to let user tune slippage/opportunity tradeoff (`maxLotDaiValue`).