### PR TITLE
Handle auctions which end without covering the tab

### DIFF
--- a/src/clipper.js
+++ b/src/clipper.js
@@ -6,6 +6,9 @@ import abacusAbi from '../abi/abacus.json';
 import clipperAbi from '../abi/clipper.json';
 import { Transact, GeometricGasPrice } from './transact.js';
 
+const decimals9 = BigNumber.from('1000000000');
+const decimals18 = ethers.utils.parseEther('1');
+const decimals27 = ethers.utils.parseEther('1000000000');
 
 export default class Clipper {
   _collateral;
@@ -57,9 +60,9 @@ export default class Clipper {
 
     // Based on the auction state, get the collateral remaining in auction or delete auction
     this._takeListener = this._clipper.on('Take', (id, max, price, owe, tab, lot, usr, event) => {
-      if (tab.eq(0)) {
+      if (lot.eq(0) || tab.eq(0)) {
         // Auction is over
-        console.log(`Deleting Auction ID: ${id.toString()} with tab ${tab.toNumber()}`);
+        console.log(`Deleting Auction ID: ${id.toString()} with remaining tab ${ethers.utils.formatUnits(tab.div(decimals27))} and lot ${ethers.utils.formatUnits(lot)}`);
         delete (this._activeAuctions[id]);
       } else {
         // Collateral remaining in auction

--- a/src/keeper.js
+++ b/src/keeper.js
@@ -102,7 +102,7 @@ export default class keeper {
           }
           slice18 = owe27.div(decimals9).div(auction.price.div(decimals27));
           if (slice18.gt(maxLot)) {  // handle corner case where maxLotDaiValue is set too low
-            console.log(`Ignoring auction ${auction.id} whose chost-adjusted slice exceeds our maximum lot\n`);
+            console.log(`Ignoring auction ${auction.id} whose chost-adjusted slice of ${ethers.utils.formatUnits(slice18)} exceeds our maximum lot of ${ethers.utils.formatUnits(maxLot)}\n`);
             continue;
           }
         }


### PR DESCRIPTION
Resolved issue removed completed auctions from the active auction list:
- When auctions settled at a price which did not cover `tab` but the whole `lot` was taken, they were not being deleted from the array.
- Attempting to print `tab.toNumber()` was causing an overflow exception which prevented deletion of a completed auction.