### PR TITLE
Bug fixes

### DIFF
--- a/src/dex/uniswap.js
+++ b/src/dex/uniswap.js
@@ -5,6 +5,7 @@ import uniswapRouter from '../../abi/UniswapV2Router02.json';
 import uniswapCalleeAbi from '../../abi/UniswapV2CalleeDai.json';
 
 export default class UniswapAdaptor {
+  // FIXME: Should not record this in state; it'll be different for each auction.
   _book = {
     sellAmount: '',
     receiveAmount: ''

--- a/src/dex/uniswap.js
+++ b/src/dex/uniswap.js
@@ -5,11 +5,6 @@ import uniswapRouter from '../../abi/UniswapV2Router02.json';
 import uniswapCalleeAbi from '../../abi/UniswapV2CalleeDai.json';
 
 export default class UniswapAdaptor {
-  // FIXME: Should not record this in state; it'll be different for each auction.
-  _book = {
-    sellAmount: '',
-    receiveAmount: ''
-  };
   _lastBlock = 0;
   _collateralName = '';
   _decNormalized;
@@ -32,6 +27,10 @@ export default class UniswapAdaptor {
   // ilkAmount in WEI
   fetch = async (_ilkAmount) => {
     let ilkAmount = BigNumber.from(_ilkAmount).div(this._decNormalized);
+    let book = {
+      sellAmount: '',
+      receiveAmount: ''
+    };
     try {
       const blockNumber = await this._provider.getBlockNumber();
       if (blockNumber === this._lastBlock) return;
@@ -40,20 +39,17 @@ export default class UniswapAdaptor {
       const offer = await this._uniswap.getAmountsOut(
         ilkAmount, Config.vars.collateral[this._collateralName].uniswapRoute
       );
-      this._book.sellAmount = ethers.utils.formatUnits(
+      book.sellAmount = ethers.utils.formatUnits(
         offer[0].mul(this._decNormalized)
       );
-      this._book.receiveAmount = ethers.utils.formatUnits(
+      book.receiveAmount = ethers.utils.formatUnits(
         offer[offer.length - 1]
       );
+      return book;
     } catch (e) {
       console.log(
         `Error fetching Uniswap amounts for ${this._collateralName}:`, e
       );
     }
-  }
-
-  opportunity = () => {
-    return this._book;
   }
 }

--- a/src/keeper.js
+++ b/src/keeper.js
@@ -69,9 +69,11 @@ export default class keeper {
         console.debug(JSON.stringify(auction));
 
         // Redo auction if it ended without covering tab or lot
-        const redone = await clip.auctionStatus(auction.id, this._wallet.address, this._wallet);
-        if (redone)
-          continue;
+        if (this._wallet) {
+          const redone = await clip.auctionStatus(auction.id, this._wallet.address, this._wallet);
+          if (redone)
+            continue;
+        }
 
         const decimals9 = BigNumber.from('1000000000');
         const decimals18 = ethers.utils.parseEther('1');
@@ -93,7 +95,6 @@ export default class keeper {
         // adjust covered debt to tab, such that slice better reflects amount of collateral we'd receive
         if (owe27.gt(tab27)) {
           owe27 = tab27;
-          // FIXME: this doesn't seem to work when auction.price < 1
           slice18 = owe27.div(decimals9).div(auction.price.div(decimals27));
         } else if (owe27.lt(tab27) && slice18.lt(auction.lot)) {
           let chost27 = clip._chost.div(decimals18);
@@ -160,8 +161,7 @@ export default class keeper {
             Auction Price:      ${ethers.utils.formatUnits(auction.price.div(decimals9))} Dai
     
             costOfLot:          ${ethers.utils.formatUnits(costOfLot)} Dai
-            minProfit:          ${ethers.utils.formatUnits(minProfit)} Dai
-            profitAddr:         ${this._wallet.address}\n`;
+            minProfit:          ${ethers.utils.formatUnits(minProfit)} Dai\n`;
 
         let liquidityAvailability;
         if (uniswap) {

--- a/src/vat.js
+++ b/src/vat.js
@@ -16,7 +16,7 @@ const clipperAllowance = async (clipperAddress, _signer) => {
             const hope_transaction = await vatContract.populateTransaction.hope(clipperAddress);
             const txn = new Transact(hope_transaction, _signer, Config.vars.txnReplaceTimeout, gasStrategy);
             const response = await txn.transact_async();
-            console.log(`Hoped Cliipper Contract in VAT ${response.hash}`);
+            console.log(`Hoped Clipper Contract in VAT ${response.hash}`);
         }
     } catch (error) {
         console.error(error);


### PR DESCRIPTION
**Bug fixes**
- `UniswapAdaptor` was inappropriately maintaining state in a local `_book` variable, causing it to non-deterministically associate `receiveAmount` with different auctions for the same collateral.  Resolved this by removing the two-step liquidity check in favor of having the promise return the value directly.
- There was an issue with `BigNumber` divided by e27 producing a `slice` of 0 for auction prices less than 1 Dai.  (Hopefully) resolved this by changing the calculation to scale after dividing.
- Made some changes to try and support the "read-only" mode advertised in the README.

Tested on Kovan, UNI-A auctions 55-58 and ZRX-A auction 3.