### PR TITLE
godsflaw-20220527: add WSTETH-B and update ETH->DAI routes

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -452,13 +452,8 @@
       "lpCurveUniv3Callee": "0x71f2198849F3B1372EA90c079BD634928583f2d2",
       "uniV3Path": [
         {
-          "fee": 500,
+          "fee": 3000,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-        },
-        {
-          "fee": 100,
-          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ],

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -21,6 +21,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -36,6 +41,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -51,6 +61,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -71,6 +86,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -91,6 +111,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -111,6 +136,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -136,6 +166,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -156,6 +191,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -176,6 +216,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -209,6 +254,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -229,6 +279,11 @@
         {
           "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -371,6 +426,22 @@
         }
       ]
     },
+    "WSTETH-B": {
+      "name": "WSTETH-B",
+      "decimals": 18,
+      "erc20addr": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "joinAdapter": "0x248cCBf4864221fC0E840F29BB042ad5bFC89B5c",
+      "clipper": "0x3ea60191b7d5990a3544B6Ef79983fD67e85494A",
+      "wstETHCurveUniv3Callee": "0xC2D837173592194131827775a6Cd88322a98C825",
+      "curvePool": "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022",
+      "uniV3Path": [
+        {
+          "fee": 3000,
+          "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+        }
+      ]
+    },
     "CRVV1ETHSTETH-A": {
       "name": "CRVV1ETHSTETH-A",
       "decimals": 18,
@@ -381,8 +452,13 @@
       "lpCurveUniv3Callee": "0x71f2198849F3B1372EA90c079BD634928583f2d2",
       "uniV3Path": [
         {
-          "fee": 3000,
+          "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ],
@@ -396,7 +472,7 @@
   "delay": "40",
   "initialGasOffsetGwei": "30",
   "dynamicGasCoefficient": "1.125",
-  "maxGasLimit": "2000000",
+  "maxGasLimit": "6000000",
   "maxGasPrice": "1000",
   "minProfitPercentage": "1.025",
   "minLotDaiValue": "0",

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -416,12 +416,17 @@
       "erc20addr": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
       "joinAdapter": "0x10CD5fbe1b404B7E19Ef964B63939907bdaf42E2",
       "clipper": "0x49A33A28C4C7D9576ab28898F4C9ac7e52EA457A",
-      "wstETHCurveUniv3Callee": "0xC2D837173592194131827775a6Cd88322a98C825",
+      "wstETHCurveUniv3Callee": "0x21540b2653FeBa52eE2c8714CA7Abfb522bb5e8C",
       "curvePool": "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022",
       "uniV3Path": [
         {
-          "fee": 3000,
+          "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]
@@ -432,12 +437,17 @@
       "erc20addr": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
       "joinAdapter": "0x248cCBf4864221fC0E840F29BB042ad5bFC89B5c",
       "clipper": "0x3ea60191b7d5990a3544B6Ef79983fD67e85494A",
-      "wstETHCurveUniv3Callee": "0xC2D837173592194131827775a6Cd88322a98C825",
+      "wstETHCurveUniv3Callee": "0x21540b2653FeBa52eE2c8714CA7Abfb522bb5e8C",
       "curvePool": "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022",
       "uniV3Path": [
         {
-          "fee": 3000,
+          "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ]

--- a/src/clipper.js
+++ b/src/clipper.js
@@ -191,13 +191,15 @@ export default class Clipper {
         [this._collateral, Config.vars.dai]
       ]);
     } else if (exchangeCalleeAddress === Config.vars.collateral[this._collateralName].wstETHCurveUniv3Callee) {
+      const route = this.encodeUniv3Route()
+
       // WstETH Curve Univ3 swap
-      typesArray = ['address', 'address', 'uint256', 'uint24', 'address'];
+      typesArray = ['address', 'address', 'uint256', 'bytes', 'address'];
       flashData = abiCoder.encode(typesArray, [
         _profitAddr,
         _gemJoinAdapter,
         _minProfit,
-        Config.vars.collateral[this._collateralName].uniV3Path[0].fee,
+        route,
         ethers.constants.AddressZero
       ]);
     } else if (exchangeCalleeAddress === Config.vars.collateral[this._collateralName].lpCurveUniv3Callee) {


### PR DESCRIPTION
this change:
- adds `WSTETH-B` to the keeper
- updates the routes from ETH->DAI to go through USDC (less gas efficient, but less slippage)
- updates the minimum gas by +4 million as anything less got out-of-gas errors for this circuit.