### PR TITLE
Support complex univ3 path also for curve LP

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -452,8 +452,13 @@
       "lpCurveUniv3Callee": "0x71f2198849F3B1372EA90c079BD634928583f2d2",
       "uniV3Path": [
         {
-          "fee": 3000,
+          "fee": 500,
           "tokenA": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "tokenB": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        },
+        {
+          "fee": 100,
+          "tokenA": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           "tokenB": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
         }
       ],


### PR DESCRIPTION
For testing this an auction can be barked (after pip price was lowered) using this:
`seth send 0x135954d155898D42C90D2a57824C690e0c7BEf1B bark(bytes32,address,address) 0x435256563145544853544554482d410000000000000000000000000000000000 0x7b6b7433a01367e9d87b6182b202f4263d5fef8c <ETH_FROM>`

The `urn` was found at https://maker.blockanalitica.com/vaults/CRVV1ETHSTETH-A/vaults/0x7b6b7433/
Then full address was actually found at:
https://etherscan.io/address/0x8377cd01a5834a6ead3b7efb482f678f2092b77e#events

